### PR TITLE
[Security] Fix 5 vulnerabilities: Hardcoded JWT Secret, DB Credentials, Mass Assignment, IDOR, Password in URL (CWE-798, CWE-915, CWE-639, CWE-598)

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -7,10 +7,10 @@ const User = require('../models/User');
 function authenticate(req, res, next) {
   User.findOne({
     where: {
-      username: req.query.username,
+      username: req.body.username,
     },
   }).then((user) => {
-    if (user && user.comparePassword(req.query.password)) {
+    if (user && user.comparePassword(req.body.password)) {
       req.dbUser = user;
       next();
     } else {

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -4,6 +4,8 @@ function load(req, res, next, id) {
   User.findById(id, { attributes: { exclude: ['password', 'refresh_token'] } }).then((user) => {
     if (!user) {
       res.status(404).json({ error: 'User not found' });
+    } else if (req.user && req.user.id !== user.id) {
+      res.status(403).json({ error: 'Forbidden — you can only access your own account' });
     } else {
       req.dbUser = user;
       next();
@@ -19,8 +21,8 @@ function get(req, res) {
 
 function create(req, res) {
   User.create({
-    username: req.query.username,
-    password: req.query.password,
+    username: req.body.username,
+    password: req.body.password,
   }, { attributes: { exclude: ['refresh_token'] } }).then((newUser) => {
     res.status(201).json(newUser);
   }).catch((e) => {
@@ -29,7 +31,17 @@ function create(req, res) {
 }
 
 function update(req, res) {
-  req.dbUser.update(req.body).then(() => {
+  const allowedFields = ['username'];
+  const updates = {};
+  allowedFields.forEach((field) => {
+    if (req.body[field] !== undefined) {
+      updates[field] = req.body[field];
+    }
+  });
+  if (Object.keys(updates).length === 0) {
+    return res.status(400).json({ error: 'No valid fields to update' });
+  }
+  req.dbUser.update(updates).then(() => {
     res.sendStatus(201);
   }).catch((e) => {
     res.status(500).json({ error: e.message });

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,13 +1,13 @@
 module.exports = {
   mysql: {
-    host: 'localhost',
-    port: 3306,
-    database: 'jwt_dev',
-    username: 'root',
-    password: 'root',
+    host: process.env.MYSQL_HOST || 'localhost',
+    port: parseInt(process.env.MYSQL_PORT, 10) || 3306,
+    database: process.env.MYSQL_DATABASE || 'jwt_dev',
+    username: process.env.MYSQL_USER || 'jwt_dev_user',
+    password: process.env.MYSQL_PASSWORD,
   },
   jwt: {
-    jwtSecret: '$eCrEt',
-    jwtDuration: '2 hours',
+    jwtSecret: process.env.JWT_SECRET,
+    jwtDuration: process.env.JWT_DURATION || '2 hours',
   },
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,13 +1,13 @@
 module.exports = {
   mysql: {
-    host: 'localhost',
-    port: 3306,
-    database: 'jwt',
-    username: 'root',
-    password: 'root',
+    host: process.env.MYSQL_HOST || 'localhost',
+    port: parseInt(process.env.MYSQL_PORT, 10) || 3306,
+    database: process.env.MYSQL_DATABASE || 'jwt',
+    username: process.env.MYSQL_USER,
+    password: process.env.MYSQL_PASSWORD,
   },
   jwt: {
-    jwtSecret: '$eCrEt',
-    jwtDuration: '2 hours',
+    jwtSecret: process.env.JWT_SECRET,
+    jwtDuration: process.env.JWT_DURATION || '2 hours',
   },
 };

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -1,13 +1,13 @@
 module.exports = {
   mysql: {
-    host: 'localhost',
-    port: 3306,
-    database: 'jwt_test',
-    username: 'root',
-    password: 'root',
+    host: process.env.MYSQL_HOST || 'localhost',
+    port: parseInt(process.env.MYSQL_PORT, 10) || 3306,
+    database: process.env.MYSQL_DATABASE || 'jwt_test',
+    username: process.env.MYSQL_USER || 'jwt_test_user',
+    password: process.env.MYSQL_PASSWORD || 'jwt_test_password',
   },
   jwt: {
-    jwtSecret: '$eCrEt',
-    jwtDuration: '2 hours',
+    jwtSecret: process.env.JWT_SECRET || 'test-jwt-secret-do-not-use-in-production',
+    jwtDuration: process.env.JWT_DURATION || '2 hours',
   },
 };


### PR DESCRIPTION
## Security Audit Report — node-jwt

Manual code audit discovered **5 security vulnerabilities** (3 Critical, 2 High).

---

### CRITICAL-1: CWE-798 Hardcoded JWT Secret (CVSS 9.8)

**Location:** config/env/development.js:10, config/env/production.js:10, config/env/test.js:10

**Data Flow:**
config/env/production.js:10 jwtSecret: '$eCrEt'
  -> config/env/index.js:2 -> config/routes/user.js:8 -> express-jwt verification

**Impact:** The JWT secret '$eCrEt' is hardcoded identically in ALL environments. Anyone with repository access can forge valid JWTs for any user.

**PoC:**
```js
const jwt = require('jsonwebtoken');
const forged = jwt.sign({ id: 1 }, '$eCrEt', { expiresIn: '2 hours' });
// Authorization: Bearer <forged> -> impersonate user id=1
```

---

### CRITICAL-2: CWE-798 Hardcoded DB Root Credentials (CVSS 9.8)

**Location:** config/env/production.js:5-7

MySQL root/root credentials hardcoded in production config.

---

### CRITICAL-3: CWE-915 Mass Assignment (CVSS 9.1)

**Location:** api/controllers/UserController.js:32

req.dbUser.update(req.body) with NO field whitelist. Attackers can overwrite password, refresh_token, or any user field.

**PoC:**
```http
PUT /users/1
Authorization: Bearer <any_valid_jwt>
{"password": "evil", "refresh_token": "hijacked"}
```

---

### HIGH-4: CWE-639 IDOR — No Ownership Check (CVSS 8.1)

GET/PUT/DELETE /users/:userId requires only a valid JWT but never checks if the requesting user owns the target account.

### HIGH-5: CWE-598 Passwords in URL Query String (CVSS 7.5)

Passwords read from req.query (URL query string) instead of req.body, exposing them in server/proxy/CDN logs.

## CVE Request

Advisory: https://github.com/saaa99999999/node-jwt/security/advisories/GHSA-cxfg-wv83-vgqg
CVE ID pending — GitHub CNA review (1-5 business days).

---