### PR TITLE
fix: the get endpoint for user profiles only require... in user.js

### DIFF
--- a/config/routes/user.js
+++ b/config/routes/user.js
@@ -20,7 +20,7 @@ router
 
 router
   .route('/:userId')
-  .get(requireJWT, userCtrl.get)
+  .get(requireJWT, userCtrl.requireOwnership, userCtrl.get)
   .put(
     requireJWT,
     validate(userValidation.update, { keyByField: true }),


### PR DESCRIPTION
## Summary
Fix high severity security issue in `config/routes/user.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `config/routes/user.js:24` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 4-step |

**Description**: The GET endpoint for user profiles only requires authentication (requireJWT) but does not enforce ownership checks. This allows any authenticated user to view any other user's profile by modifying the userId parameter in the request, violating the principle of least privilege.

## Evidence

**Exploitation scenario**: An attacker authenticates as user A (id=1) and obtains a valid JWT token.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This route handler appears to be publicly accessible. This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `config/routes/user.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
